### PR TITLE
fix: exit non-zero when database actions fail

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import logging
 from helpers.utils import generate_secure_random_string
 from services.supabase_service import SupabaseClient
@@ -127,6 +128,8 @@ def main():
                 logging.info(f"  Delete Success: {status['success_delete']}")
             else:
                 logging.info("  Delete Success: N/A")
+
+    sys.exit(0 if all_successful else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When database actions fail (403, permission errors, offline DB, etc.), the script logs a warning but still exits 0. The GitHub Action shows 🟢 green even though inserts silently failed. This happened to users in #3 where Supabase projects were getting paused despite "successful" workflow runs.

## Fix

Added `import sys` and `sys.exit(0 if all_successful else 1)` at the end of `main()`. 

- All databases succeed → exits 0 (green)
- Any database fails → exits 1 (red, triggers failure notifications)

## Verification

Tested in forked repo — a run with a 403 permission error on one table correctly showed as failed, while a subsequent run with permissions fixed showed green.